### PR TITLE
Set the body and description as comments to avoid loosing html/xml code for example

### DIFF
--- a/trac-hub
+++ b/trac-hub
@@ -344,6 +344,9 @@ class Migrator
     str.gsub!(/\br(\d+)\b/)              { map_changeset(Regexp.last_match[1]) }
     # Ticket
     str.gsub!(/ticket:(\d+)/, '#\1')
+    # set the body as a comment
+    str.gsub!("\n", "\n> ")
+    str = "> #{str}"
     return str
   end
 end


### PR DESCRIPTION
When there are html-like elements in the description of a track ticket or on its comments, we loose them as it is not displayed on the end github page.
This PR displays the content of the comment and the description as quotes (which makes some sense as it is quotes from the previous ticket and it makes it easier to read in the final render.