### PR TITLE
Make sure the basic tickets elements are in as labels

### DIFF
--- a/trac-hub
+++ b/trac-hub
@@ -204,6 +204,14 @@ class Migrator
         closed = x[:time]
       end
     end
+    labels.add(@labels.fetch('component', Hash[])[ticket[:component]])
+    labels.add(@labels.fetch('type', Hash[])[ticket[:type]])
+    labels.add(@labels.fetch('resolution', Hash[])[ticket[:resolution]])
+    labels.add(@labels.fetch('priority', Hash[])[ticket[:priority]])
+    labels.add(@labels.fetch('severity', Hash[])[ticket[:severity]])
+    labels.add(@labels.fetch('version', Hash[])[ticket[:version]])
+    # If the field is not set, it will be nil and generate an unprocessable json
+    labels.delete(nil)
 
     issue = {
       "title" => ticket[:summary],


### PR DESCRIPTION
If the ticket is created with attributes already set and never changed after (at least in the version of trac I was testing with), these attributes never appear in the ticket_change table, hence are not set as labels on the tickets on github. This change ensures that the final attributes on the ticket are pushed as labels for sure.