### PR TITLE
Fix merge issue & update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Add the `-v` flag for more verbose output:
 
     ./trac-hub -v
 
+Add the `-o` flag to only import the tickets that are not in a `closed` status:
+
+    ./trac-hub -o
+
 To resume the migration at a given trac ticket ID, use `-s`:
 
     ./trac-hub -s 42

--- a/trac-hub
+++ b/trac-hub
@@ -405,6 +405,7 @@ class Options < Hash
       end
       opts.on('-o', '--opened-only', 'Skips the import of closed tickets') do |o|
         self[:openedonly] = o
+      end
       opts.on('-v', '--verbose', 'verbose mode') do |v|
         self[:verbose] = v
       end


### PR DESCRIPTION
There's been a hiccup during the merge: a `end` disappeared, so when you run trac-hub on master you get:
```
SyntaxError: trac-hub:469: syntax error, unexpected end-of-input, expecting keyword_end
```
This PR fixes that and adds a mention of the `-o` switch in the `README.md` 