### PR TITLE
Assigning GitHub Issue based on Trac's ticket owner and username mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,7 @@ tracker does not have a first-class notion of ticket priority, type, and
 version information, trac-hub supports expressing these in the form of labels.
 
 The section `users` contains a one-to-one mapping between trac usernames or
-email addresses and github usernames for users for which no github credentials
-are known or can't be used and are thus not stored in the `github` section. As
-soon as you have the login credentials for a user please use the `github`
-`logins` section in the config instead.
+email addresses and github usernames.
 
 Dependencies
 ------------

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -6,6 +6,7 @@ github:
   repo: 'mavam/test'
   token: '49b1c8d34401abc06040cf64bf9a8bfed5f30ca9'
 
+# make sure not to typo the GitHub username as the issue will fail to create if a ticket's owner (assignee) has a valid mapping below
 users:
   matthias: mavam
   vallenti: mavam

--- a/trac-hub
+++ b/trac-hub
@@ -221,7 +221,7 @@ class Migrator
       "closed" => ticket[:status] == "closed",
       "created_at" => format_time(ticket[:time]),
     }
-    if @users.has_key?(owner)
+    if @users.has_key?(ticket[:owner])
       owner = trac_mail(ticket[:owner])
       github_owner = @users[owner]
       $logger.debug("..owner in trac: #{owner}")

--- a/trac-hub
+++ b/trac-hub
@@ -214,34 +214,19 @@ class Migrator
     # If the field is not set, it will be nil and generate an unprocessable json
     labels.delete(nil)
 
-    # trac owner / assignee info and mapping to github user
-    owner = ticket[:owner]
-    owner = trac_mail(owner)
-    $logger.debug("..owner in trac: #{owner}")
+    issue = {
+      "title" => ticket[:summary],
+      "body" => body,
+      "labels" => labels.to_a,
+      "closed" => ticket[:status] == "closed",
+      "created_at" => format_time(ticket[:time]),
+    }
     if @users.has_key?(owner)
-      githubOwner = @users[owner]
-    end
-    $logger.debug("..assignee in GitHub: #{githubOwner}")
-    
-    if githubOwner
-      # create w/ assignee
-      issue = {
-        "title" => ticket[:summary],
-        "body" => body,
-        "labels" => labels.to_a,
-        "assignee" => githubOwner,
-        "closed" => ticket[:status] == "closed",
-        "created_at" => format_time(ticket[:time]),
-      }
-    else
-      # create w/o assignee
-      issue = {
-        "title" => ticket[:summary],
-        "body" => body,
-        "labels" => labels.to_a,
-        "closed" => ticket[:status] == "closed",
-        "created_at" => format_time(ticket[:time]),
-      }
+      owner = trac_mail(ticket[:owner])
+      github_owner = @users[owner]
+      $logger.debug("..owner in trac: #{owner}")
+      $logger.debug("..assignee in GitHub: #{github_owner}")
+      issue["assignee"] = github_owner
     end
 
     if ticket[:changetime]

--- a/trac-hub
+++ b/trac-hub
@@ -214,13 +214,35 @@ class Migrator
     # If the field is not set, it will be nil and generate an unprocessable json
     labels.delete(nil)
 
-    issue = {
-      "title" => ticket[:summary],
-      "body" => body,
-      "labels" => labels.to_a,
-      "closed" => ticket[:status] == "closed",
-      "created_at" => format_time(ticket[:time]),
-    }
+    # trac owner / assignee info and mapping to github user
+    owner = ticket[:owner]
+    owner = trac_mail(owner)
+    $logger.debug("..owner in trac: #{owner}")
+    if @users.has_key?(owner)
+      githubOwner = @users[owner]
+    end
+    $logger.debug("..assignee in GitHub: #{githubOwner}")
+    
+    if githubOwner
+      # create w/ assignee
+      issue = {
+        "title" => ticket[:summary],
+        "body" => body,
+        "labels" => labels.to_a,
+        "assignee" => githubOwner,
+        "closed" => ticket[:status] == "closed",
+        "created_at" => format_time(ticket[:time]),
+      }
+    else
+      # create w/o assignee
+      issue = {
+        "title" => ticket[:summary],
+        "body" => body,
+        "labels" => labels.to_a,
+        "closed" => ticket[:status] == "closed",
+        "created_at" => format_time(ticket[:time]),
+      }
+    end
 
     if ticket[:changetime]
       issue["updated_at"] = format_time(ticket[:changetime])


### PR DESCRIPTION
I liked that this tool supported using the Issue Import API's to allow for original creation time date/time stamps, but I was disappointed that it didn't carry through the Trac Owner --> GitHub Issue Assignee - this is my implementation of this.

* If Trac-->GitHub username mapping exists, use it where Trac ticket owner is mapped to GitHub Issue Assignee. 

* Added a note in the config to remind people to make sure not to typo their GitHub username mappings - an issue will fail to create if a mapping is found but the GitHub user does not exist:
```yaml
# make sure not to typo the GitHub username as the issue will fail to create if a ticket's owner (assignee) has a valid mapping below
```

* I also removed the GitHub Users login / old github username mapping content in the reaadme.


A potential improvement idea would be to use the GitHub user API to validate that a user exists before continuing with the migration - this should be used by both github issue assignee AND the Issue body / comments - If you migrate with an invalid mapping in the non-forked code, their will be a `@username` in the issue body that does not reference a GitHub user, therefore it is not a link and just plain text.